### PR TITLE
 Add shell.nix file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ This project requires that you have at least:
 * [Psc-Package](https://github.com/purescript/psc-package/) installed, with the release binary in your PATH in some way.
 * [jq](https://github.com/stedolan/jq) installed.
 
+If you use the [nix package manager](https://nixos.org/nix) you can open a shell with all dependencies by using the provided `shell.nix` file:
+
+```
+nix-shell --pure shell.nix
+```
+
 ### How files are organized
 
 ```hs

--- a/scripts/add-from-bower.pl
+++ b/scripts/add-from-bower.pl
@@ -1,4 +1,6 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+
+use warnings;
 
 =head1 add-from-bower.pl
 

--- a/scripts/prepare-bower.pl
+++ b/scripts/prepare-bower.pl
@@ -1,4 +1,6 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+
+use warnings;
 
 =head1 prepare-bower.pl
 

--- a/scripts/update-from-bower.pl
+++ b/scripts/update-from-bower.pl
@@ -1,4 +1,6 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+
+use warnings;
 
 =head1 update-from-bower.pl
 

--- a/scripts/validate.pl
+++ b/scripts/validate.pl
@@ -1,4 +1,6 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+
+use warnings;
 
 =head1 validate.pl
 

--- a/scripts/verify.pl
+++ b/scripts/verify.pl
@@ -1,4 +1,6 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
+
+use warnings;
 
 =head1 verify.pl
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+
+mkShell {
+  buildInputs = [
+    dhall
+    dhall-json
+    perl
+    jq
+  ];
+}


### PR DESCRIPTION
Use `nix-shell --pure` to open a shell with all dependencies.

Changes all perl invocations to use `env`. Since the linux kernel splits
shebangs only on the first whitespace, the `-w` has to be replaced by perl’s
`use warnings;` pragma.