### PR TITLE
shell.nix: add locales and LC_ALL for dhall to work

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,5 +8,9 @@ mkShell {
     dhall-json
     perl
     jq
+    # TODO: remove once https://github.com/dhall-lang/dhall-haskell/issues/504 is fixed
+    glibcLocales
   ];
+  # TODO: like glibc locales
+  LC_ALL = "en_US.UTF-8";
 }


### PR DESCRIPTION
dhall does some handle encoding incorrectly. This means a command like:

dhall << "./src/packages.dhall"

fails with an encoding error if the locale is not setup correctly.