### PR TITLE
scripts: add Prefetch.hs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ If you use the [nix package manager](https://nixos.org/nix) you can open a shell
 nix-shell --pure shell.nix
 ```
 
+There is also a more minimal shell without the Haskell script dependencies available:
+
+```
+nix-shell --pure -A small shell.nix
+```
+
 ### How files are organized
 
 ```hs
@@ -98,6 +104,15 @@ You will only need the following scripts:
 * `update-from-bower.pl` - to update a package that is registered on Bower.
 
 These each take an argument of a package, e.g. `./update-from-bower.pl behaviors`.
+
+### Using Haskell scripts in this repository
+
+```
+$ nix-shell --pure --run "runhaskell scripts/Prefetch.hs" \
+    | tee hashes.json
+```
+
+Outputs a record of all package’s git repository hashsums, by calling the nix prefetch scripts. Useful for consecutive building of Purescript packages with nix.
 
 ## Further Complaints
 

--- a/scripts/Prefetch.hs
+++ b/scripts/Prefetch.hs
@@ -1,0 +1,249 @@
+{-# LANGUAGE DeriveFunctor, DeriveTraversable, GeneralizedNewtypeDeriving, RecordWildCards, DeriveGeneric, LambdaCase, NoImplicitPrelude, OverloadedStrings, NamedFieldPuns, TupleSections #-}
+
+module Main where
+
+import Protolude hiding (sym, retry)
+import qualified Text.Show as Show
+import Control.Monad.Catch (Handler(..))
+import qualified Data.HashMap.Strict as HM
+import qualified Data.HashMap.Strict.InsOrd as HMIO
+import qualified Data.Sequence as Seq
+import Data.Either.Validation
+
+import qualified Data.Text as T
+
+import qualified Dhall as D
+import qualified Dhall.Core as DC
+import Dhall.Parser (Src)
+import qualified Dhall.Parser
+import qualified Dhall.Import
+import Dhall.TypeCheck (X)
+import qualified Dhall.TypeCheck
+
+import qualified Data.Text.Prettyprint.Doc as Pretty
+import qualified Data.Text.Prettyprint.Doc.Render.Text as PrettyText
+
+import qualified Control.Concurrent.Async.Pool as Async
+import Control.Retry (RetryStatus(..), recovering, exponentialBackoff)
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Encode.Pretty as AesonPretty
+import qualified Foreign.Nix.Shellout.Prefetch as P
+import GHC.Generics (Generic)
+
+
+-- Dhall library code
+
+-- | Package name.
+newtype PName = PName { unPName :: D.Text }
+  deriving (Show, Eq, Hashable, Aeson.ToJSONKey)
+-- | HashMap with package names as keys.
+type PMap a = HM.HashMap PName a
+-- | InsOrdHashMap with package names as keys.
+type PMapIO a = HMIO.InsOrdHashMap PName a
+
+-- | Spacchetthi packages cannot be read.
+data CompileError
+ = WrongPackageTypes (PMapIO ())
+   -- ^ a package has the wrong type
+ | ToplevelNotSet (DC.Expr X X)
+   -- ^ the toplevel value is not a set
+ deriving (Typeable)
+
+instance Show CompileError where
+  show err = toS $ T.intercalate "\n" $
+    [ _ERROR <> ": Cannot parse package set"
+    , "" ]
+    <> msg err
+
+    where
+      msg :: CompileError -> [D.Text]
+      msg (WrongPackageTypes ts) =
+        [ "Explanation: The outermost record must only contain packages."
+        , ""
+        , "The following fields where not packages:"
+        , ""
+        , "↳ " <> DC.pretty
+            (listLit $ fmap (textLit . unPName)
+                     $ HMIO.keys ts :: DC.Expr X X)
+        ]
+      msg (ToplevelNotSet tl) =
+        [ "Explanation: The outermost value must be a record of packages."
+        , ""
+        , "The record was:"
+        , ""
+        , "↳ " <> pretty tl
+        ]
+
+pretty :: Pretty.Pretty a => DC.Expr s a -> D.Text
+pretty = PrettyText.renderStrict
+        . Pretty.layoutPretty Pretty.defaultLayoutOptions
+        . Pretty.pretty
+
+textLit :: D.Text -> DC.Expr s a
+textLit = DC.TextLit . DC.Chunks []
+
+listLit :: [(DC.Expr s a)] -> DC.Expr s a
+listLit = DC.ListLit Nothing . Seq.fromList
+
+instance Exception CompileError
+
+_ERROR :: D.Text
+_ERROR = "\ESC[1;31mError\ESC[0m"
+
+-- | A spacchetti package.
+data Package = Package
+  { dependencies :: [Text]
+    -- ^ list of dependency package names
+  , repo :: Text
+    -- ^ the git repository
+  , version :: Text }
+    -- ^ version string (also functions as a git ref)
+  deriving (Show, Generic)
+
+-- | Takes a map of Dhall record fields and tries to parse
+-- them as packages. That is it type-checks and normalizes
+-- each field and accumulates errors.
+packages :: PMapIO (DC.Expr Src X)
+         -> Validation
+             (PMapIO (Dhall.TypeCheck.TypeError Src X))
+             (PMapIO Package)
+packages = HMIO.traverseWithKey (\k e -> toVal k $ toPkg k e)
+  where
+    toVal name = either (Failure . HMIO.singleton name) Success
+    toPkg :: PName -> DC.Expr Src X
+          -> Either (Dhall.TypeCheck.TypeError Src X) Package
+    toPkg (PName name) pkgExpr = do
+      let pkgType = D.genericAuto :: D.Type Package
+      -- we annotate the expression with the type we want,
+      -- then typeOf will check the type for us
+      -- TODO: do we have to test if there is an annotation already?
+      let eAnnot = DC.Annot pkgExpr
+                   $ D.expected pkgType
+      -- typeOf only returns the type, which we already know
+      _ <- Dhall.TypeCheck.typeOf eAnnot
+      -- the normalize is not strictly needed (we already normalized
+      -- the expressions that were given to this function)
+      -- but it converts the @DC.Expr s a@ @s@ arguments to any @t@,
+      -- which is needed for @extract@ to type check with @eAnnot@
+      case D.extract pkgType $ DC.normalize $ eAnnot of
+        Just x -> pure x
+        Nothing -> DC.internalError
+          $ "packages: " <> toS name <> " has an InvalidType\n"
+          <> toS (pretty (DC.denote eAnnot :: DC.Expr X X))
+
+
+-- Fetching of repositories
+
+parallelTasks, numberOfRetries, retryBaseDelayMs :: Int
+-- | Number of repositories to fetch at the same time.
+parallelTasks = 5
+-- | Number of times to retry fetching a repository.
+numberOfRetries = 5
+-- | Base delay between retries, increases with @n^2@.
+retryBaseDelayMs = 500
+
+-- | Exception that is thrown when a fetch fails.
+newtype Err = Err (P.NixActionError P.PrefetchError)
+  deriving (Show)
+
+instance Exception Err
+
+-- | Fetch all given packages, and always a pool of 'parallelTasks'
+-- packages at the same time.
+--
+-- Takes a 'Chan' that recieves a message when a fetch is starting,
+-- with information about the package and the number of retries.
+--
+-- Returns a Map of package name to hashes, or throws 'Err' if a
+-- fetch failed even after some retries.
+fetchAllParallel :: Chan (PName, RetryStatus)
+                 -- ^ messages package name that is currently fetched
+                 -> PMap Package
+                 -> IO (PMap P.Sha256)
+fetchAllParallel chan pkgs = Async.withTaskGroup parallelTasks
+  $ \taskGroup -> do
+      job <- atomically $ Async.mapReduce taskGroup actions
+      fetched <- Async.wait job
+      pure $ HM.fromList fetched
+  where
+    -- ATTN: if the retry fails, it throws an exception.
+    -- I hate that, but otherwise Async.Pool just continues. :(
+    -- Update: even with an Exception, it also continues. TODO
+    -- | Construct a list of package fetch actions that
+    -- each are retried a few times, with exponential backoff.
+    actions :: [IO [(PName, P.Sha256)]]
+    actions = flip map (HM.toList pkgs) $ \pkg -> do
+      a <- recovering
+        (exponentialBackoff retryBaseDelayMs)
+        [should]
+        (action pkg)
+      pure [a]
+
+    -- | Whether a fetch should be retried.
+    should :: RetryStatus -> Handler IO Bool
+    should RetryStatus{rsIterNumber} = Handler
+          $ \(Err _) -> pure $ rsIterNumber < numberOfRetries
+
+    -- | One fetch.
+    action :: (PName, Package)
+           -> RetryStatus
+           -> IO (PName, P.Sha256)
+    action (name, Package{repo, version}) rs = do
+      liftIO $ writeChan chan (name, rs)
+      let opt = (P.defaultGitOptions $ P.Url repo)
+                  { P.gitRev = Just version }
+      eith <- P.runNixAction $ P.gitOutputSha256
+          <$> P.git opt
+      case eith of
+        Left err -> throwIO $ Err err
+        Right sha -> pure $ (name, sha)
+
+
+-- Main
+
+-- | Path to the file to read.
+packagesDhall :: Text
+packagesDhall = "./src/packages.dhall"
+
+main :: IO ()
+main = do
+  expr  <- throws (Dhall.Parser.exprFromText mempty packagesDhall)
+  expr' <- Dhall.Import.load expr
+  go $ DC.normalize expr'
+  where
+    go :: DC.Expr Src X -> IO ()
+    go = \case
+
+      -- reads the outermost record into and calls everything
+      (DC.RecordLit hm) ->
+        case packages $ HMIO.mapKeys PName hm of
+        Failure errs -> throwIO
+          $ WrongPackageTypes $ fmap (const ()) errs
+        Success pkgs ->
+          (fetch (HMIO.toHashMap pkgs)
+            >>= putStr . AesonPretty.encodePretty . fmap P.unSha256)
+          `catch` (\(Err (P.NixActionError{..})) ->
+                      die $ show actionError <> "\n"
+                         <> actionStderr)
+
+      -- outermost value was not a record
+      e -> throwIO $ ToplevelNotSet (DC.denote e)
+
+    -- | Calls the fetcher.
+    fetch pkgs = do
+      nowFetching <- newChan
+      bracket
+        (forkIO $ forever $
+          readChan nowFetching
+          >>= \(PName name, RetryStatus{rsIterNumber}) -> putErrLn
+                (  "Fetching repo for "
+                <> name
+                <> " (retry "
+                <> Protolude.show rsIterNumber <> ")" :: D.Text ))
+        killThread
+        $ const $ fetchAllParallel nowFetching pkgs
+
+    throws :: Exception e => Either e a -> IO a
+    throws (Left  e) = throwIO e
+    throws (Right r) = return r

--- a/shell.nix
+++ b/shell.nix
@@ -56,10 +56,12 @@ let
     # we copy a lot of stuff of the haskellPackages env builder,
     # because it is unfortunately not very composable.
     LANG = "en_US.UTF-8";
-    # TODO: remove once https://github.com/dhall-lang/dhall-haskell/issues/504 is fixed
-    LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
     inherit (h.libnix.env) shellHook;
-  });
+  } // (if glibcLocales != null
+    # TODO: remove once https://github.com/dhall-lang/dhall-haskell/issues/504 is fixed
+    then { LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive"; }
+    else {})
+  );
 
 in
 mkShell (fullShellArgs // {

--- a/shell.nix
+++ b/shell.nix
@@ -17,20 +17,8 @@ let
         };
         license = lib.licenses.gpl3;
         buildDepends = with self; [ protolude aeson errors tasty-hunit ];
-        # buildTools = [ nix ];
         doCheck = false;
       };
-      # package for creating a shell with all tools
-      # spacchetti-tools =
-      #   let packages = with self; [ libnix dhall ];
-      #   in super.mkDerivation {
-      #     pname = "spacchetti-tools";
-      #     version = "none";
-      #     license = "none";
-      #     buildDepends = packages;
-      #     buildTools = with self;
-      #       [ cabal-install (hoogleLocal { inherit packages; }) ];
-      #   };
     };
   };
 
@@ -43,28 +31,38 @@ let
     insert-ordered-containers
     retry
   ];
-in
-mkShell {
-  buildInputs = [
-    dhall
-    dhall-json
-    perl
-    jq
-    psc-package
-  ] ++ hDeps;
-  nativeBuildInputs = [
-    h.cabal-install
-    (h.hoogleLocal { packages = hDeps; })
-    (h.ghcWithPackages (lib.const hDeps))
-    nix-prefetch-scripts
-  ];
 
-  # for ghc
-  # we copy a lot of stuff of the haskellPackages env builder,
-  # because it is unfortunately not very composable.
-  LANG = "en_US.UTF-8";
-  # TODO: remove once https://github.com/dhall-lang/dhall-haskell/issues/504 is fixed
-  LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
-  inherit (h.libnix.env) shellHook;
-}
+  overrideAttrs = attrs: f: attrs // f attrs;
+
+  smallShellArgs = {
+    buildInputs = [
+      dhall
+      dhall-json
+      perl
+      jq
+      psc-package
+    ];
+  };
+
+  fullShellArgs = overrideAttrs smallShellArgs (old: {
+    buildInputs = old.buildInputs ++ hDeps;
+    nativeBuildInputs = [
+      h.cabal-install
+      (h.hoogleLocal { packages = hDeps; })
+      (h.ghcWithPackages (lib.const hDeps))
+      nix-prefetch-scripts
+    ];
+    # for ghc
+    # we copy a lot of stuff of the haskellPackages env builder,
+    # because it is unfortunately not very composable.
+    LANG = "en_US.UTF-8";
+    # TODO: remove once https://github.com/dhall-lang/dhall-haskell/issues/504 is fixed
+    LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
+    inherit (h.libnix.env) shellHook;
+  });
+
+in
+mkShell (fullShellArgs // {
+  passthru.small = mkShell smallShellArgs;
+})
 

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,48 @@
 
 with pkgs;
 
+let
+  h = haskellPackages.override {
+    overrides = self: super: {
+      # libnix pinning
+      libnix = super.mkDerivation {
+        pname = "libnix";
+        version = "0.3.0";
+        src = fetchFromGitHub {
+          owner = "Profpatsch";
+          repo = "libnix-haskell";
+          rev = "b891f4f425da5fa3e7e06bce98c56cf6cb6c876c";
+          sha256 = "00wbz83mlgqq5ml7ysdw6wfr74grpac7sj3v9cylvhy2blx922yp";
+        };
+        license = lib.licenses.gpl3;
+        buildDepends = with self; [ protolude aeson errors tasty-hunit ];
+        # buildTools = [ nix ];
+        doCheck = false;
+      };
+      # package for creating a shell with all tools
+      # spacchetti-tools =
+      #   let packages = with self; [ libnix dhall ];
+      #   in super.mkDerivation {
+      #     pname = "spacchetti-tools";
+      #     version = "none";
+      #     license = "none";
+      #     buildDepends = packages;
+      #     buildTools = with self;
+      #       [ cabal-install (hoogleLocal { inherit packages; }) ];
+      #   };
+    };
+  };
+
+  hDeps = with h; [
+    libnix
+    dhall
+    aeson-pretty
+    either
+    async-pool
+    insert-ordered-containers
+    retry
+  ];
+in
 mkShell {
   buildInputs = [
     dhall
@@ -9,9 +51,20 @@ mkShell {
     perl
     jq
     psc-package
-    # TODO: remove once https://github.com/dhall-lang/dhall-haskell/issues/504 is fixed
-    glibcLocales
+  ] ++ hDeps;
+  nativeBuildInputs = [
+    h.cabal-install
+    (h.hoogleLocal { packages = hDeps; })
+    (h.ghcWithPackages (lib.const hDeps))
+    nix-prefetch-scripts
   ];
-  # TODO: like glibc locales
-  LC_ALL = "en_US.UTF-8";
+
+  # for ghc
+  # we copy a lot of stuff of the haskellPackages env builder,
+  # because it is unfortunately not very composable.
+  LANG = "en_US.UTF-8";
+  # TODO: remove once https://github.com/dhall-lang/dhall-haskell/issues/504 is fixed
+  LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
+  inherit (h.libnix.env) shellHook;
 }
+

--- a/spacchetti.cabal
+++ b/spacchetti.cabal
@@ -1,0 +1,35 @@
+name:                spachetti
+version:             0.1.0.0
+build-type:          Simple
+cabal-version:       >=1.10
+
+extra-source-files:  
+
+   
+executable spachetti-prefetch
+  main-is: scripts/Prefetch.hs
+  other-modules:       
+  build-depends:       base >=4.9 && <5
+                     , text
+                     , exceptions
+                     , containers
+                     , unordered-containers
+                     , insert-ordered-containers
+                     , stm
+                     , protolude ==0.2.*
+                     , either == 5.*
+                     , aeson >= 1.0.0.0 && < 1.5.0.0
+                     , aeson-pretty == 0.8.*
+                     , dhall == 1.15.*
+                     , prettyprinter >= 1.2.0.1 && < 1.3
+                     , libnix == 0.2.*
+                     , async-pool ==0.9.*
+                     , retry == 0.7.*
+  -- hs-source-dirs:      
+  ghc-options:        -Wall
+  default-extensions:  NoImplicitPrelude
+                     , OverloadedStrings
+                     , LambdaCase
+                     , TupleSections
+                     , ViewPatterns
+  default-language:    Haskell2010


### PR DESCRIPTION
To run:

```
$ nix-shell --pure --run "runhaskell scripts/Prefetch.hs" \
    | tee hashes.json
```

Prefetch.hs is an experiment of calling directly into the Dhall
library to read spacchetti. Dhall has no concept of a map of values
with uniform type, so we match into the syntax tree manually and then
check each package.

It will use libnix to prefetch the git repositories and output a json
of hashes. The prefetching clones five repositories at a time and
retries on network errors.

@justinwoo this made me notice that the your `unordered-collections` patch can’t be fetched any more.