### PR TITLE
Sets SHELL to /bin/bash for `generate`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ format:
 	@ls src/**/*.dhall | xargs -I{} dhall format --inplace {}
 	@echo formatted dhall files
 
+
+generate: SHELL:=/bin/bash
 generate:
 	@dhall-to-json --pretty <<< "./src/packages.dhall" > packages.json
 	@psc-package format

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ format:
 	@ls src/**/*.dhall | xargs -I{} dhall format --inplace {}
 	@echo formatted dhall files
 
-
 generate: SHELL:=/bin/bash
 generate:
 	@dhall-to-json --pretty <<< "./src/packages.dhall" > packages.json


### PR DESCRIPTION
If `SHELL` is not set to `/bin/bash`, `make generate` fails with a "redirection unexpected" error.
This pr fixes it.